### PR TITLE
Add Markdown-Videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Compute:
 - [Slackers](https://github.com/uhavin/slackers) - Slack webhooks API.
 - [TermPair](https://github.com/cs01/termpair) - View and control terminals from your browser with end-to-end encryption.
 - [Universities](https://github.com/ycd/universities) - API service for obtaining information about +9600 universities worldwide.
+- [Markdown-Videos](https://github.com/Snailedlt/Markdown-Videos) - API for generating thumbnails to embed into your markdown content.
 
 ## Sponsors
 


### PR DESCRIPTION
Markdown-Videos is an API that generates video thumbnails for youtube and vimeo videos based on their video ID's, which can be used anywhere, but is intended for markdown usage.

Check out the repo here: https://github.com/Snailedlt/Markdown-Videos

It's deployed with Vercel using serverless functions, so it could potentially replace the vercel example since it uses a more modern approach with a `vercel.json` file in the root of the project.